### PR TITLE
Improve /server API routes

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,9 @@
   "main": "src/index.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node build/index.js"
+    "start": "node build/index.js",
+    "build": "npx tsc",
+    "build:watch": "npx tsc -w"
   },
   "author": "",
   "license": "ISC",

--- a/server/src/actions/createMessage.ts
+++ b/server/src/actions/createMessage.ts
@@ -1,0 +1,12 @@
+import { doc, setDoc } from '@firebase/firestore'
+import { messages } from '../utilities/firebaseInit'
+
+export const createMessage = async (userId, msgId, msgContent, recievingUserIds) => {
+   const newMsgRef = doc(messages, msgId) 
+   setDoc(newMsgRef, {
+       userId: userId,
+       msgId: msgId,
+       msgContent: msgContent,
+       recievingUserIds: recievingUserIds
+   })
+}

--- a/server/src/actions/getMessages.ts
+++ b/server/src/actions/getMessages.ts
@@ -1,14 +1,21 @@
 import { getDocs } from '@firebase/firestore'
-import { messages } from '../scripts/firebaseInit'
+import { messages } from '../utilities/firebaseInit'
 
 export const getMessages = async () => {
   const messageDocs = await getDocs(messages)
+  const messageObjs = [];
 
-  messageDocs.docs.forEach((messageDoc) => {
-    const message = messageDoc.data()
-    console.log(messageDoc)
-    // console.log(messageDoc.userId)
-    // console.log(messageDoc.msgId)
-    // console.log(messageDoc.msgContent)
+  messageDocs.docs.forEach((doc) => {
+    const data = doc.data()
+    const messageObj = {
+        userId: data.userId,
+        msgId: data.msgId,
+        msgContent: data.msgContent,
+        recievingUserIds: data.recievingUserIds
+        
+    }
+    messageObjs.push(messageObj);
   })
+
+  return messageObjs;
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,20 +1,43 @@
 import express from 'express';
 import { getMessages } from './actions/getMessages'
+import { createMessage } from './actions/createMessage'
 
-const app = express();
-const port = 3000;
+const app = express()
+const port = 3000
+app.use(express.json())
+app.use(express.urlencoded({ extended: true }))
+
 
 app.get('/', (req, res) => {
-  res.send('Hello World!');
-});
+  res.send('Hello World!')
+})
 
 app.get('/messages', async (req, res) => {
     // get messages from fb
     const messages = await getMessages()
-    res.send(messages)
+    res.json(messages)
+})
+
+app.post('/messages/new', async (req, res) => {
+    try {
+        await createMessage(
+            req.body.userId,
+            req.body.msgId,
+            req.body.msgContent,
+            req.body.recievingUserIds
+        )
+        // Send back "true" if message was successfully created.
+        res.json(true)
+
+    } catch (e) {
+        console.log("/messages/new: request sent with incorrect data format.")
+        res.json(false)
+
+    }
+
 })
 
 app.listen(port, () => {
-  return console.log(`Listening at http://localhost:${port}`);
-});
+  return console.log(`Listening at http://localhost:${port}`)
+})
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -8,10 +8,10 @@ app.get('/', (req, res) => {
   res.send('Hello World!');
 });
 
-app.get('/messages', (req, res) => {
+app.get('/messages', async (req, res) => {
     // get messages from fb
-    getMessages()
-    res.send("messages path")
+    const messages = await getMessages()
+    res.send(messages)
 })
 
 app.listen(port, () => {

--- a/server/src/types/Message.ts
+++ b/server/src/types/Message.ts
@@ -2,4 +2,5 @@ export interface Message {
     userId: string
     msgId: string
     msgContent: string
+    recievingUserIds: string
 }

--- a/server/src/utilities/firebaseInit.ts
+++ b/server/src/utilities/firebaseInit.ts
@@ -3,7 +3,6 @@ import { getFirestore, CollectionReference, collection, DocumentData } from 'fir
 import 'dotenv/config'
 
 // Make sure that config is up to date in /.env
-console.log(process.env.apiKey)
 export const firebaseApp = initializeApp({
   apiKey: process.env.apiKey,
   authDomain: process.env.authDomain,
@@ -23,7 +22,7 @@ const createCollection = <T = DocumentData>(collectionName: string) => {
 // Import types
 import { Message } from '../types/Message'
 
-// export all your collections
+// Export collections
 export const messages = createCollection<Message>('messages')
 
-console.log("Database initated.")
+console.log("Database synced")

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -5,7 +5,8 @@
     "target": "es6",
     "moduleResolution": "node",
     "sourceMap": true,
-    "outDir": "build"
+    "outDir": "build",
+    "rootDir": "src"
   },
   "lib": ["es2015"]
 }


### PR DESCRIPTION
Updated GET request to /messages to now return a JSON object with the message data instead of just printing to the console as a proof of concept. POST request to /messages/new will also create a new message document in Firebase.

I also renamed /server/src/scripts to /server/src/utilities since I thought the naming would make more sense.