### PR TITLE
[Back-end] Added multiple endpoints for /messages and /users

### DIFF
--- a/ApiChecklist.md
+++ b/ApiChecklist.md
@@ -72,13 +72,13 @@ Please reference one of these when creating a new _action_.
 
 * add a Message document to the Messages collection in Firestore
 
-- [ ] DELETE /messages?msgId=\<msgId\>
+- [x] DELETE /messages?msgId=\<msgId\>
 
 * Delete a message document with the corresponding msgId
 
 ### Users
 
-- [ ] GET /users?userId=\<userId\>
+- [x] GET /users?userId=\<userId\>
 
 * return a user document with a matching userId
 

--- a/ApiChecklist.md
+++ b/ApiChecklist.md
@@ -90,6 +90,6 @@ Please reference one of these when creating a new _action_.
 
 *  update specificLat and specificLon location attributes of a user with matching userId to values specified in the query
 
-- [ ] DELETE /users?userId=\<userId\>
+- [x] DELETE /users?userId=\<userId\>
 
 * Delete a user document with the corresponding userId

--- a/server/src/actions/createUser.ts
+++ b/server/src/actions/createUser.ts
@@ -1,11 +1,12 @@
 import { doc, setDoc } from "firebase/firestore";
 import { users } from "../utilities/firebaseInit";
 
-export const createUser = async (userId: string, userDisplayName: string) => {
+export const createUser = async (userId: string, displayName: string, avatarUrl: string) => {
     const newUserRef = doc(users, userId)
     setDoc(newUserRef, {
         userId: userId,
-        userDisplayName: userDisplayName,
+        displayName: displayName,
+        avatarUrl: avatarUrl,
         broadLat: "0",
         broadLon: "0",
         specificLat: "0",

--- a/server/src/actions/deleteMessage.ts
+++ b/server/src/actions/deleteMessage.ts
@@ -1,5 +1,5 @@
 import { doc, getDoc, deleteDoc} from '@firebase/firestore'
-import { messages, firestore } from '../utilities/firebaseInit'
+import { messages } from '../utilities/firebaseInit'
 
 export const deleteMessageById = async (msgId: string) => {
   const msgRef = doc(messages, msgId)

--- a/server/src/actions/deleteMessages.ts
+++ b/server/src/actions/deleteMessages.ts
@@ -1,16 +1,31 @@
-import { doc, deleteDoc} from '@firebase/firestore'
+import { doc, getDoc, deleteDoc} from '@firebase/firestore'
 import { messages, firestore } from '../utilities/firebaseInit'
 
 export const deleteMessageById = async (msgId: string) => {
   const msgRef = doc(messages, msgId)
-  const msgDoc = await deleteDoc(msgRef)
 
-  return true
-  // if (msgDoc.exists()) {
-  //     return msgDoc.data()
-  // } else {
-  //     // If no data is returned, index.ts will notice and throw an error accordingly.
-  //     return
-  // }
+  // The promise returned by deleteDoc will be fulfilled (aka return 'true') both if the document requested for deletion exists or doesn't exist. It is rejected if the program is unable to send this request to Firestore.
+  // Therefore, we need to check to see if the document exists first, to most accurately know if it will be deleted.
+  // However, technically, there could be some kind of failure by deleteDoc after this check is performed, where the status of the deletion would then be inaccurately returned.
+  // TODO: find a way to assuredly know if a document is deleted after deleteDoc is called.
+
+  const msgDoc = await getDoc(msgRef)
+  // Do not attempt to delete the requested doc if it does not exist.
+  if (!msgDoc.exists()) {
+      return false
+  }
+
+  const deletionStatus = await deleteDoc(msgRef)
+    .then(
+        // .then()'s first parameter runs on success, and the second runs when there is an error
+        () => { 
+            return true
+        },
+        () => { 
+            return false
+        }
+    )
+
+  return deletionStatus
 }
 

--- a/server/src/actions/deleteMessages.ts
+++ b/server/src/actions/deleteMessages.ts
@@ -1,0 +1,16 @@
+import { doc, deleteDoc} from '@firebase/firestore'
+import { messages, firestore } from '../utilities/firebaseInit'
+
+export const deleteMessageById = async (msgId: string) => {
+  const msgRef = doc(messages, msgId)
+  const msgDoc = await deleteDoc(msgRef)
+
+  return true
+  // if (msgDoc.exists()) {
+  //     return msgDoc.data()
+  // } else {
+  //     // If no data is returned, index.ts will notice and throw an error accordingly.
+  //     return
+  // }
+}
+

--- a/server/src/actions/deleteUser.ts
+++ b/server/src/actions/deleteUser.ts
@@ -1,0 +1,31 @@
+import { doc, getDoc, deleteDoc} from '@firebase/firestore'
+import { users } from '../utilities/firebaseInit'
+
+export const deleteUserById = async (userId: string) => {
+  const userRef = doc(users, userId)
+
+  // The promise returned by deleteDoc will be fulfilled (aka return 'true') both if the document requested for deletion exists or doesn't exist. It is rejected if the program is unable to send this request to Firestore.
+  // Therefore, we need to check to see if the document exists first, to most accurately know if it will be deleted.
+  // However, technically, there could be some kind of failure by deleteDoc after this check is performed, where the status of the deletion would then be inaccurately returned.
+  // TODO: find a way to assuredly know if a document is deleted after deleteDoc is called.
+
+  const userDoc = await getDoc(userRef)
+  // Do not attempt to delete the requested doc if it does not exist.
+  if (!userDoc.exists()) {
+      return false
+  }
+
+  const deletionStatus = await deleteDoc(userRef)
+    .then(
+        // .then()'s first parameter runs on success, and the second runs when there is an error
+        () => { 
+            return true
+        },
+        () => { 
+            return false
+        }
+    )
+
+  return deletionStatus
+}
+

--- a/server/src/actions/getMessages.ts
+++ b/server/src/actions/getMessages.ts
@@ -16,6 +16,7 @@ export const getMessages = async () => {
     }
     messageObjs.push(messageObj);
 
+    // TODO: use Firestore limiter when requesting messages
     // This section adds to the message counter and returns if 100 messages have been received!
     messagesReceived++
     if (messagesReceived >= 100) {

--- a/server/src/actions/getUsers.ts
+++ b/server/src/actions/getUsers.ts
@@ -1,24 +1,36 @@
-import { getDocs } from '@firebase/firestore'
-import { messages } from '../utilities/firebaseInit'
-import { calculateCoordinateBoundaries } from '../utilities/calculateCoordinateBoundaries'
+import { doc, getDoc } from '@firebase/firestore'
+import { users } from '../utilities/firebaseInit'
+// import { calculateCoordinateBoundaries } from '../utilities/calculateCoordinateBoundaries'
 
-export const getNearbyUsers = async (coords: Array<number>) => {
-    const lat = coords[0]
-    const lon = coords[1]
-    const coordBoundries = await calculateCoordinateBoundaries(lat, lon)
+export const getUserById = async (userId: string) => {
+    const userRef = doc(users, userId)
+    const userDoc = await getDoc(userRef)
 
-    // Upper and Lower x bounds
-    const lowerX = coordBoundries[0][0]
-    const upperX = coordBoundries[1][0]
-
-    // Upper and Lower y bounds
-    const lowerY = coordBoundries[0][1]
-    const upperY = coordBoundries[1][1]
-
-    // ## Place Firebase Query HERE ## 
-
-    // PLACEHOLDER RESPONSE
-    const response = `Looking in X range ${lowerX} to ${upperX} and Y range ${lowerY} to ${upperY}`
-
-    return response
+    if (userDoc.exists()) {
+        return userDoc.data()
+    } else {
+        return
+    }
 }
+
+// ## Work towards getting nearby messages ##
+// export const getNearbyUsers = async (coords: Array<number>) => {
+//     const lat = coords[0]
+//     const lon = coords[1]
+//     const coordBoundries = await calculateCoordinateBoundaries(lat, lon)
+//
+//     // Upper and Lower x bounds
+//     const lowerX = coordBoundries[0][0]
+//     const upperX = coordBoundries[1][0]
+//
+//     // Upper and Lower y bounds
+//     const lowerY = coordBoundries[0][1]
+//     const upperY = coordBoundries[1][1]
+//
+//     // ## Place Firebase Query HERE ##
+//
+//     // PLACEHOLDER RESPONSE
+//     const response = `Looking in X range ${lowerX} to ${upperX} and Y range ${lowerY} to ${upperY}`
+//
+//     return response
+// }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,8 +1,9 @@
 import express, { json } from 'express'
 import { getMessages, getMessageById, getMessagesByBroadCoordinates, getMessagesByBroadCoordsAndTime } from './actions/getMessages'
+import { createMessage } from './actions/createMessage'
+import { deleteMessageById } from './actions/deleteMessages'
 import { convertToBroadCoordinates } from './utilities/convertToBroadCoordinates'
 import { getNearbyUsers } from './actions/getUsers'
-import { createMessage } from './actions/createMessage'
 import { createUser } from './actions/createUsers'
 import { updateUserLocation } from './actions/updateUser'
 
@@ -69,6 +70,8 @@ app.get('/messages', async (req, res) => {
 })
 
 app.post('/messages', async (req, res) => {
+    let returnData = null
+
     try {
         // Make sure time is valid before attempting to create message.
         const timeSent = Number(req.body.timeSent)
@@ -90,6 +93,30 @@ app.post('/messages', async (req, res) => {
         console.log("Error: (POST /messages) request sent with incorrect data format.")
         res.json(false)
     }
+})
+
+app.delete('/messages', async (req, res) => {
+    let returnData = null
+
+    if (req.query.msgId) {
+        try {
+            const msgId = req.query.msgId
+            if (typeof msgId === "string") {
+                returnData = await deleteMessageById(msgId)
+            }
+        } catch(e) {
+            console.log("Error:")
+            console.log(e)
+        }
+    }
+
+    if (returnData === null) {
+        // Return error to client
+        res.json(false)
+    } else {
+        res.json(returnData)
+    }
+    return
 })
 
 app.post('/users', async (req, res) => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -146,32 +146,6 @@ app.put('*', (req, res) => {
     res.json("404: Path could not be found! COULD NOT {PUT}")
 })
 
-// ### TESTING ENDPOINTS ###
-
-// For message objects
-
-// Get message obj by broad coordinates
-app.get("/messages/get/broad/:lat/:lon", async (req, res) => {
-    let lat = Number(req.params.lat)
-    let lon = Number(req.params.lon)
-
-    const response = await convertToBroadCoordinates([lat, lon])
-    res.json(response)
-})
-
-// For user objects
-
-app.get("/users/get/specificRange/:lat/:lon", async (req, res) => {
-    let lat = Number(req.params.lat)
-    let lon = Number(req.params.lon)
-
-    const response = await getNearbyUsers([lat, lon])
-
-    res.json(response)
-})
-
-// ######
-
 app.listen(port, () => {
   return console.log(`Listening at http://localhost:${port}`)
 })

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -87,7 +87,7 @@ app.post('/messages', async (req, res) => {
         // Send back "true" if message was successfully created.
         res.json(true)
     } catch (e) {
-        console.log("POST /messages: request sent with incorrect data format.")
+        console.log("Error: (POST /messages) request sent with incorrect data format.")
         res.json(false)
     }
 })

--- a/server/src/types/User.ts
+++ b/server/src/types/User.ts
@@ -1,6 +1,7 @@
 export interface User {
-    userDisplayName: string
+    displayName: string
     userId: string
+    avatarUrl: string
     broadLat: string
     broadLon: string
     specificLat: string


### PR DESCRIPTION
* Endpoints for `DELETE /messages?msgId=<msgId>`, `GET /users?userId=<userId>`, `DELETE /users?userId=<userId>` have been added
* Endpoint for `POST /users` has been updated

This PR finishes the rest of the routes specified in ApiChecklist. Logic has been added for deleting documents in Firebase, however there is a bug where we won't actually know if a particular document has been actually deleted or not. I attempted to circumvent this by checking to see if a requested document exists in the database before deleting it, which prevents this issue to a much greater capacity, but not completely since the `deleteDoc()` function provided by Firestore can still technically fail. Further research should be done in the security of the delete actions especially if the app starts to scale. Further information about this issue are specified in comments in their respecting files in `/server/src/actions`.

Besides that, the other route added in `/messages` and the one updated in `/users` were added quite trivially. Tested too, of course.

That said, I think its also worth considering making a `PUT` route for `/messages` taking in a `msgId`, since then we would be able to add functionality for editing them after being sent to Firestore.