### PR TITLE
Modularize NearbyHeader component

### DIFF
--- a/client/src/components/Common/NearbyCount.tsx
+++ b/client/src/components/Common/NearbyCount.tsx
@@ -16,13 +16,7 @@ const NearbyCount: React.FC<CounterProps> = ({count}) => {
         <View style={styles.iconContainer}>
             <View style={styles.iconAndCount}>
             <Image style={styles.iconImage} source={require("../../../assets/nearby_icon.png")}/>
-            <Text style={{
-                fontSize: 20,
-                fontWeight: 'bold',
-                color: 'black',
-                textAlign:"center",
-                width: "50%",
-            }}>{count}</Text>
+            <Text style={styles.countText}>{count}</Text>
             </View>
         </View>
     )
@@ -39,6 +33,13 @@ const styles = StyleSheet.create({
     iconAndCount:{
         alignSelf: "flex-end",
         alignItems: "center"
+    },
+    countText: {
+        fontSize: 20,
+        fontWeight: 'bold',
+        color: 'black',
+        textAlign:"center",
+        width: "50%",
     }
 });
 

--- a/client/src/components/Common/NearbyCount.tsx
+++ b/client/src/components/Common/NearbyCount.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import {
+    View,
+    Image,
+    StyleSheet,
+    Text,
+    Dimensions
+} from 'react-native';
+
+interface CounterProps {
+    count: number;
+}
+
+const NearbyCount: React.FC<CounterProps> = ({count}) => {
+    return (
+        <View style={styles.iconContainer}>
+            <View style={styles.iconAndCount}>
+            <Image style={styles.iconImage} source={require("../../../assets/nearby_icon.png")}/>
+            <Text style={{
+                fontSize: 20,
+                fontWeight: 'bold',
+                color: 'black',
+                textAlign:"center",
+                width: "50%",
+            }}>{count}</Text>
+            </View>
+        </View>
+    )
+}
+
+const styles = StyleSheet.create({
+    iconImage:{
+        height: Dimensions.get('window').height * 0.025,
+        width: Dimensions.get('window').height * 0.03
+    },
+    iconContainer:{
+        width: "50%"
+    },
+    iconAndCount:{
+        alignSelf: "flex-end",
+        alignItems: "center"
+    }
+});
+
+export default NearbyCount;

--- a/client/src/components/Common/NearbyHeader.tsx
+++ b/client/src/components/Common/NearbyHeader.tsx
@@ -1,40 +1,37 @@
-
-import { View, Text, StyleSheet, Dimensions, Image } from 'react-native'
-import React from 'react'
-import NearbyCount from './NearbyCount';
+import { View, Text, StyleSheet, Dimensions } from "react-native";
+import React from "react";
+import NearbyCount from "./NearbyCount";
 
 interface CounterProps {
-    count: number;
+  count: number;
 }
 
 export const NearbyHeader: React.FC<CounterProps> = ({ count }) => {
-    return (
-        <View style={styles.nearbyContainer}>
-            <View style={{flexDirection: "row"}}>
-                <Text style={{
-                    fontSize: 30,
-                    fontWeight: 'bold',
-                    color: 'black',
-                    textAlign:"left",
-                    width: "35%",
-                    marginLeft: "5%",
-                }}>Nearby</Text>
-                <NearbyCount count={count} />
-            </View>
-        </View>
-    )
-  }
+  return (
+    <View style={styles.nearbyContainer}>
+      <View style={{ flexDirection: "row" }}>
+        <Text style={styles.nearbyText}>Nearby</Text>
+        <NearbyCount count={count} />
+      </View>
+    </View>
+  );
+};
 
-
-
-  const styles = StyleSheet.create({
+const styles = StyleSheet.create({
   nearbyContainer: {
-    paddingTop: Dimensions.get('window').height * 0.01,
-    paddingBottom: Dimensions.get('window').height * 0.01,
-    flexDirection:'row',
+    paddingTop: Dimensions.get("window").height * 0.01,
+    paddingBottom: Dimensions.get("window").height * 0.01,
+    flexDirection: "row",
     alignItems: "center",
-    
-  }
+  },
+  nearbyText: {
+    fontSize: 30,
+    fontWeight: "bold",
+    color: "black",
+    textAlign: "left",
+    width: "35%",
+    marginLeft: "5%",
+  },
 });
 
 export default NearbyHeader;

--- a/client/src/components/Common/NearbyHeader.tsx
+++ b/client/src/components/Common/NearbyHeader.tsx
@@ -1,35 +1,25 @@
 
 import { View, Text, StyleSheet, Dimensions, Image } from 'react-native'
 import React from 'react'
+import NearbyCount from './NearbyCount';
 
 interface CounterProps {
     count: number;
-  }
+}
 
 export const NearbyHeader: React.FC<CounterProps> = ({ count }) => {
     return (
         <View style={styles.nearbyContainer}>
-        <View style={{flexDirection: "row"}}>
-        <Text style={{
-                fontSize: 30,
-                fontWeight: 'bold',
-                color: 'black',
-                textAlign:"left",
-                width: "35%",
-                marginLeft: "5%",
-            }}>Nearby</Text>
-            <View style={styles.iconContainer}>
-                <View style={styles.iconAndCount}>
-            <Image style={styles.iconImage} source={require("../../../assets/nearby_icon.png")}/>
-            <Text style={{
-                fontSize: 20,
-                fontWeight: 'bold',
-                color: 'black',
-                textAlign:"center",
-                width: "50%",
-            }}>{count}</Text>
-            </View>
-            </View>
+            <View style={{flexDirection: "row"}}>
+                <Text style={{
+                    fontSize: 30,
+                    fontWeight: 'bold',
+                    color: 'black',
+                    textAlign:"left",
+                    width: "35%",
+                    marginLeft: "5%",
+                }}>Nearby</Text>
+                <NearbyCount count={count} />
             </View>
         </View>
     )
@@ -44,19 +34,7 @@ export const NearbyHeader: React.FC<CounterProps> = ({ count }) => {
     flexDirection:'row',
     alignItems: "center",
     
-  },
-  iconImage:{
-    height: Dimensions.get('window').height * 0.025,
-    width: Dimensions.get('window').height * 0.03,
-    
-    },
-    iconContainer:{
-        width: "50%"
-    },
-    iconAndCount:{
-        alignSelf: "flex-end",
-        alignItems: "center"
-    }
+  }
 });
 
 export default NearbyHeader;


### PR DESCRIPTION
Closes #115

I have duplicated the type for the count props in the child component as well. I'm thinking that we should store the types for all the props associated with the different components in a seperate folder of its own so that the design is cleaner.