### PR TITLE
Enabled Location Data gathering and also connecting sockets between Client and Server

### DIFF
--- a/client/app.json
+++ b/client/app.json
@@ -28,7 +28,13 @@
       "favicon": "./assets/favicon.png"
     },
     "plugins": [
-      "expo-router"
+      "expo-router",
+      [
+        "expo-location",
+        {
+          "locationAlwaysAndWhenInUsePermission": "Allow OSC Proximity Chat to access your location."
+        }
+      ]
     ]
   }
 }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -21,6 +21,7 @@
         "expo-linear-gradient": "~12.3.0",
         "expo-linking": "~5.0.2",
         "expo-location": "~16.1.0",
+        "expo-network": "~5.4.0",
         "expo-router": "^2.0.0",
         "expo-secure-store": "~12.3.1",
         "expo-status-bar": "~1.6.0",
@@ -11048,6 +11049,14 @@
       "dependencies": {
         "compare-versions": "^3.4.0",
         "invariant": "^2.2.4"
+      }
+    },
+    "node_modules/expo-network": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/expo-network/-/expo-network-5.4.0.tgz",
+      "integrity": "sha512-6Hdm6CRmt7KpEYSTp9Q0fH1V63Y3tLlgkZfJBqJHksxEP/ooOjBLsK8M09q+FiWsStByI/PKj6NO86+uymz5ig==",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-pwa": {

--- a/client/package.json
+++ b/client/package.json
@@ -35,7 +35,8 @@
     "react-native-screens": "~3.22.0",
     "react-native-uuid": "^2.0.1",
     "react-native-web": "~0.19.6",
-    "socket.io-client": "^4.7.4"
+    "socket.io-client": "^4.7.4",
+    "expo-network": "~5.4.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/client/src/app/(home)/_layout.tsx
+++ b/client/src/app/(home)/_layout.tsx
@@ -1,18 +1,24 @@
 import React from "react";
 import { Stack } from "expo-router";
 import { SettingsProvider } from "../../contexts/SettingsContext";
+import { SocketProvider } from "../../contexts/SocketContext";
+import { LocationProvider } from "../../contexts/LocationContext";
 
 const AuthLayout = () => {
   return (
-    <SettingsProvider>
-      <Stack
-        screenOptions={{
-          headerShown: false,
-        }}
-      >
-        <Stack.Screen name="chatchannel" options={{}} />
-      </Stack>
-    </SettingsProvider>
+    <LocationProvider>
+      <SocketProvider>
+        <SettingsProvider>
+          <Stack
+            screenOptions={{
+              headerShown: false,
+            }}
+          >
+            <Stack.Screen name="chatchannel" options={{}} />
+          </Stack>
+        </SettingsProvider>
+      </SocketProvider>
+    </LocationProvider>
   );
 };
 

--- a/client/src/contexts/LocationContext.tsx
+++ b/client/src/contexts/LocationContext.tsx
@@ -1,65 +1,81 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
 import * as Location from "expo-location";
+import { LOCATION_REFRESH_RATE } from "@env";
 
 interface LocationContextProps {
-    longitude: number;
-    latitude: number;
-    isLocationEnabled: boolean;
+  longitude: number;
+  latitude: number;
+  isLocationEnabled: boolean;
 }
 
 interface LocationType {
-    longitude: number;
-    latitude: number;
+  longitude: number;
+  latitude: number;
 }
 
 const LocationContext = createContext<LocationContextProps | null>(null);
 
 export const useLocation = () => {
-    return useContext(LocationContext);
+  return useContext(LocationContext);
 };
 
-export const LocationProvider = ({ children }: { children: React.ReactNode }) => {
-    const [location, setLocation] = useState<LocationType>({
-        latitude: 99999, // Impossible starting value
-        longitude: 99999,
-    });
-    const [isLocationEnabled, setIsLocationEnabled] = useState(false);
+export const LocationProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [location, setLocation] = useState<LocationType>({
+    latitude: 99999, // Impossible starting value
+    longitude: 99999,
+  });
+  const [isLocationEnabled, setIsLocationEnabled] = useState(false);
 
-    useEffect(() => {
-        (async () => {
-            // Request location permissions, if not granted, return
-            let { status } = await Location.requestForegroundPermissionsAsync();
-            if (status !== "granted") {
-                console.log("Permission to access location was denied");
-                return;
-            }
+  useEffect(() => {
+    (async () => {
+      // Request location permissions, if not granted, return
+      let { status } = await Location.requestForegroundPermissionsAsync();
+      if (status !== "granted") {
+        console.log("Permission to access location was denied");
+        return;
+      }
 
-            setIsLocationEnabled(true);
+      setIsLocationEnabled(true);
 
-            const interval = setInterval(async () => {
-                try {
-                    let locationData = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Highest }); // High accuracy for now for testing!
-                    if (locationData.coords.latitude !== location.latitude || locationData.coords.longitude !== location.longitude) {
-                        setLocation({
-                            latitude: locationData.coords.latitude,
-                            longitude: locationData.coords.longitude,
-                        });
-                    } else {
-                        console.log("Location has not changed");
-                    }
-                } catch (error) {
-                    console.error("Error fetching location:", error);
-                }
-            }, 3000); // Fetch location every 3 seconds
+      const interval = setInterval(async () => {
+        try {
+          let locationData = await Location.getCurrentPositionAsync({
+            accuracy: Location.Accuracy.Highest,
+          }); // High accuracy for now for testing!
+          if (
+            locationData.coords.latitude !== location.latitude ||
+            locationData.coords.longitude !== location.longitude
+          ) {
+            setLocation({
+              latitude: locationData.coords.latitude,
+              longitude: locationData.coords.longitude,
+            });
+          } else {
+            console.log("Location has not changed");
+          }
+        } catch (error) {
+          console.error("Error fetching location:", error);
+        }
+      }, LOCATION_REFRESH_RATE); // Fetch location every 3 seconds
 
-            // Cleanup function to clear interval when component unmounts
-            return () => clearInterval(interval);
-        })();
-    }, []); 
+      // Cleanup function to clear interval when component unmounts
+      return () => clearInterval(interval);
+    })();
+  }, []);
 
-    return (
-        <LocationContext.Provider value={{ longitude: location.longitude, latitude: location.latitude, isLocationEnabled: isLocationEnabled }}>
-            {children}
-        </LocationContext.Provider>
-    );
+  return (
+    <LocationContext.Provider
+      value={{
+        longitude: location.longitude,
+        latitude: location.latitude,
+        isLocationEnabled: isLocationEnabled,
+      }}
+    >
+      {children}
+    </LocationContext.Provider>
+  );
 };

--- a/client/src/contexts/LocationContext.tsx
+++ b/client/src/contexts/LocationContext.tsx
@@ -1,0 +1,65 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+import * as Location from "expo-location";
+
+interface LocationContextProps {
+    longitude: number;
+    latitude: number;
+    isLocationEnabled: boolean;
+}
+
+interface LocationType {
+    longitude: number;
+    latitude: number;
+}
+
+const LocationContext = createContext<LocationContextProps | null>(null);
+
+export const useLocation = () => {
+    return useContext(LocationContext);
+};
+
+export const LocationProvider = ({ children }: { children: React.ReactNode }) => {
+    const [location, setLocation] = useState<LocationType>({
+        latitude: 99999, // Impossible starting value
+        longitude: 99999,
+    });
+    const [isLocationEnabled, setIsLocationEnabled] = useState(false);
+
+    useEffect(() => {
+        (async () => {
+            // Request location permissions, if not granted, return
+            let { status } = await Location.requestForegroundPermissionsAsync();
+            if (status !== "granted") {
+                console.log("Permission to access location was denied");
+                return;
+            }
+
+            setIsLocationEnabled(true);
+
+            const interval = setInterval(async () => {
+                try {
+                    let locationData = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Highest }); // High accuracy for now for testing!
+                    if (locationData.coords.latitude !== location.latitude || locationData.coords.longitude !== location.longitude) {
+                        setLocation({
+                            latitude: locationData.coords.latitude,
+                            longitude: locationData.coords.longitude,
+                        });
+                    } else {
+                        console.log("Location has not changed");
+                    }
+                } catch (error) {
+                    console.error("Error fetching location:", error);
+                }
+            }, 3000); // Fetch location every 3 seconds
+
+            // Cleanup function to clear interval when component unmounts
+            return () => clearInterval(interval);
+        })();
+    }, []); 
+
+    return (
+        <LocationContext.Provider value={{ longitude: location.longitude, latitude: location.latitude, isLocationEnabled: isLocationEnabled }}>
+            {children}
+        </LocationContext.Provider>
+    );
+};

--- a/client/src/contexts/SocketContext.tsx
+++ b/client/src/contexts/SocketContext.tsx
@@ -17,7 +17,7 @@ export const SocketProvider = ({ children }: { children: React.ReactNode }) => {
   useEffect(() => {
     let isMounted = true;
 
-    const socketIo = io(`http://10.136.187.71:8080`); // Hardcoded IP address
+    const socketIo = io(`http://${EXPO_IP}:8080`); // Hardcoded IP address
 
     socketIo.on("connect", () => {
       if (isMounted) {

--- a/client/src/contexts/SocketContext.tsx
+++ b/client/src/contexts/SocketContext.tsx
@@ -16,7 +16,7 @@ export const SocketProvider = ({ children }: { children: React.ReactNode }) => {
   useEffect(() => {
     let isMounted = true;
 
-    const socketIo = io('http://10.144.50.42:8080'); // Hardcoded IP address
+    const socketIo = io('http://{your-expo-ip}:8080'); // Hardcoded IP address
 
     socketIo.on('connect', () => {
       if (isMounted) {

--- a/client/src/contexts/SocketContext.tsx
+++ b/client/src/contexts/SocketContext.tsx
@@ -17,7 +17,7 @@ export const SocketProvider = ({ children }: { children: React.ReactNode }) => {
   useEffect(() => {
     let isMounted = true;
 
-    const socketIo = io(`http://${EXPO_IP}:8080`); // Hardcoded IP address
+    const socketIo = io(`http://10.136.187.71:8080`); // Hardcoded IP address
 
     socketIo.on("connect", () => {
       if (isMounted) {

--- a/client/src/contexts/SocketContext.tsx
+++ b/client/src/contexts/SocketContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { io, Socket } from 'socket.io-client';
 import * as Network from 'expo-network';
+import { useLocation } from './LocationContext';
 
 const SocketContext = createContext<Socket | null>(null);
 
@@ -10,23 +11,43 @@ export const useSocket = () => {
 
 export const SocketProvider = ({ children }: { children: React.ReactNode }) => {
   const [socket, setSocket] = useState<Socket | null>(null);
+  const locationContext = useLocation();
 
   useEffect(() => {
-    const fetchIP = async () => {
-      try {
-        const networkState = await Network.getNetworkStateAsync();
-        if (networkState.isConnected) {
-          const ip = await Network.getIpAddressAsync();
-          const socketIo = io(`http://${ip}:8080`); // Dynamically fetches and uses the IP address
-          setSocket(socketIo);
-        }
-      } catch (error) {
-        console.error('Could not get IP address:', error);
-      }
-    };
+    let isMounted = true;
 
-    fetchIP();
+    const socketIo = io('http://10.144.50.42:8080'); // Hardcoded IP address
+
+    socketIo.on('connect', () => {
+      if (isMounted) {
+        setSocket(socketIo);
+      } else {
+        console.log('Socket not mounted');
+      }
+    });
+
+    socketIo.on('message', (data: any) => {
+      console.log('message', data);
+    });
+
+    return () => {
+      isMounted = false;
+      socket?.disconnect();
+    };
   }, []);
+
+  useEffect(() => {
+    if (socket && locationContext?.latitude != 9999 && locationContext?.longitude != 9999) {
+      console.log('Sending location update to server:', locationContext?.latitude, locationContext?.longitude);
+      socket.emit('updateLocation', {
+        lat: locationContext?.latitude,
+        lon: locationContext?.longitude,
+      }, (ack: string) => {
+        console.log('Location update ack:', ack);
+      });
+
+    }
+  }, [locationContext?.latitude, locationContext?.longitude])
 
   return <SocketContext.Provider value={socket}>{children}</SocketContext.Provider>;
 };

--- a/client/src/contexts/SocketContext.tsx
+++ b/client/src/contexts/SocketContext.tsx
@@ -1,7 +1,8 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
-import { io, Socket } from 'socket.io-client';
-import * as Network from 'expo-network';
-import { useLocation } from './LocationContext';
+import React, { createContext, useContext, useEffect, useState } from "react";
+import { io, Socket } from "socket.io-client";
+import * as Network from "expo-network";
+import { useLocation } from "./LocationContext";
+import { EXPO_IP } from "@env";
 
 const SocketContext = createContext<Socket | null>(null);
 
@@ -16,18 +17,18 @@ export const SocketProvider = ({ children }: { children: React.ReactNode }) => {
   useEffect(() => {
     let isMounted = true;
 
-    const socketIo = io('http://{your-expo-ip}:8080'); // Hardcoded IP address
+    const socketIo = io(`http://${EXPO_IP}:8080`); // Hardcoded IP address
 
-    socketIo.on('connect', () => {
+    socketIo.on("connect", () => {
       if (isMounted) {
         setSocket(socketIo);
       } else {
-        console.log('Socket not mounted');
+        console.log("Socket not mounted");
       }
     });
 
-    socketIo.on('message', (data: any) => {
-      console.log('message', data);
+    socketIo.on("message", (data: any) => {
+      console.log("message", data);
     });
 
     return () => {
@@ -37,17 +38,30 @@ export const SocketProvider = ({ children }: { children: React.ReactNode }) => {
   }, []);
 
   useEffect(() => {
-    if (socket && locationContext?.latitude != 9999 && locationContext?.longitude != 9999) {
-      console.log('Sending location update to server:', locationContext?.latitude, locationContext?.longitude);
-      socket.emit('updateLocation', {
-        lat: locationContext?.latitude,
-        lon: locationContext?.longitude,
-      }, (ack: string) => {
-        console.log('Location update ack:', ack);
-      });
-
+    if (
+      socket &&
+      locationContext?.latitude != 9999 &&
+      locationContext?.longitude != 9999
+    ) {
+      console.log(
+        "Sending location update to server:",
+        locationContext?.latitude,
+        locationContext?.longitude
+      );
+      socket.emit(
+        "updateLocation",
+        {
+          lat: locationContext?.latitude,
+          lon: locationContext?.longitude,
+        },
+        (ack: string) => {
+          console.log("Location update ack:", ack);
+        }
+      );
     }
-  }, [locationContext?.latitude, locationContext?.longitude])
+  }, [locationContext?.latitude, locationContext?.longitude]);
 
-  return <SocketContext.Provider value={socket}>{children}</SocketContext.Provider>;
+  return (
+    <SocketContext.Provider value={socket}>{children}</SocketContext.Provider>
+  );
 };


### PR DESCRIPTION
Closes #86 

Changlog:
- Added Location Context for Location Retrieval
- Fixed up Socket Context to use with EXPO's local IP.
- Added error checking and ack() into socket context when emitting!

After a few months of trying, the frontend and the backend have finally been connected!
Some tips: Location is set to highest due to testing, will most likely be on low for actual production!

Contexts are very intertwined!!! :star: 
