### PR TITLE
Added red borders to the Text Input on the Login Screen when the Authentication fails

### DIFF
--- a/client/src/components/Auth/LoginScreen.tsx
+++ b/client/src/components/Auth/LoginScreen.tsx
@@ -25,6 +25,7 @@ const LoginScreen = () => {
   const { inputEmail } = useLocalSearchParams();
   const [email, setEmail] = React.useState<string>("");
   const [password, setPassword] = React.useState<string>("");
+  const [invalidLogin, invalidateLogin] = React.useState<boolean>(false);
 
   const onHandleSubmit = async () => {
     const response = await appSignIn(email, password);
@@ -32,6 +33,7 @@ const LoginScreen = () => {
       router.replace("(home)/chatchannel");
     } else if (response?.error) {
       console.log(response.error);
+      invalidateLogin(true);
     }
   };
 
@@ -56,10 +58,12 @@ const LoginScreen = () => {
             <LogInEmailInput
               value={email}
               onChangeText={(text) => setEmail(text)}
+              invalid={invalidLogin}
             />
             <LogInPasswordInput
               value={password}
               onChangeText={(text) => setPassword(text)}
+              invalid={invalidLogin}
             />
           </View>
           <View style={styles.button_container}>

--- a/client/src/components/Common/CustomInputs.tsx
+++ b/client/src/components/Common/CustomInputs.tsx
@@ -4,6 +4,7 @@ import { TextInput, View, StyleSheet, Dimensions, Platform } from 'react-native'
 interface ChatInputProps {
     value?: string,
     onChangeText?: (text: string) => void
+    invalid?: boolean,
 }
 
 export const WelcomeEmailInput: React.FC<ChatInputProps> = ({ value, onChangeText }) => {
@@ -19,9 +20,9 @@ export const WelcomeEmailInput: React.FC<ChatInputProps> = ({ value, onChangeTex
 
 // Maybe will put LogInEmailInput & LogInPasswordInput two together into a single component
 
-export const LogInEmailInput: React.FC<ChatInputProps> = ({ value, onChangeText }) => {
+export const LogInEmailInput: React.FC<ChatInputProps> = ({ value, onChangeText, invalid }) => {
     return (
-        <TextInput style={styles.loginInput}
+        <TextInput style={[styles.loginInput, invalid && styles.invalidLoginInput]}
         placeholder='Email'
         multiline={false}
         value={value}
@@ -30,9 +31,9 @@ export const LogInEmailInput: React.FC<ChatInputProps> = ({ value, onChangeText 
     )
 }
 
-export const LogInPasswordInput: React.FC<ChatInputProps> = ({ value, onChangeText}) => {
+export const LogInPasswordInput: React.FC<ChatInputProps> = ({ value, onChangeText, invalid }) => {
     return (
-        <TextInput style={styles.loginInput}
+        <TextInput style={[styles.loginInput, invalid && styles.invalidLoginInput]}
         placeholder='Password'
         multiline={false}
         value={value}
@@ -101,6 +102,10 @@ const styles = StyleSheet.create({
         paddingBottom: Platform.OS === 'ios' ? 15 : 0,
         paddingLeft: 15,
         paddingRight: 15,
+    },
+
+    invalidLoginInput: {
+        borderColor: 'red',
     },
 
 });


### PR DESCRIPTION
Added a prop to ChatInputProps so that when appSignIn returns error, the text inputs for LogInEmailInput and LogInPasswordInput will have a red border.