### PR TITLE
Fixed missing confirmPassword input box

### DIFF
--- a/client/src/components/Auth/SignUpScreen.tsx
+++ b/client/src/components/Auth/SignUpScreen.tsx
@@ -70,6 +70,10 @@ const SignUpScreen = () => {
                 value={password}
                 onChangeText={(text) => setPassword(text)}
               />
+              <SignUpPasswordInput
+                value={confirmPassword}
+                onChangeText={(text) => setConfirmPassword(text)}
+              />
             </View>
             <View style={styles.button_container}>
               <SignUpButton onPress={onHandleSubmit} />


### PR DESCRIPTION
For some reason the "confirmPassword" input box was missing in the sign up page, but there _was_ variables for it. I added it here.