### PR TITLE
Integrate client-server message sending and retrival

### DIFF
--- a/client/src/components/Chat/ChatScreen.tsx
+++ b/client/src/components/Chat/ChatScreen.tsx
@@ -38,12 +38,17 @@ const ChatScreen = () => {
   const [messages, setMessages] = React.useState<MessageType[]>([]);
   const [messageContent, setMessageContent] = React.useState<string>("");
 
-  if (socket === null) return // This line might need to be changed.
-  socket.on("message", (data: MessageType, ack) => {
-    console.log("Message recieved from server:", data);
-    if (ack) console.log("Server acknowledged message:", ack);
-    setMessages([...messages, data])
-  })
+  useEffect(() => {
+    if (socket === null) return // This line might need to be changed.
+    socket.on("message", (data: MessageType, ack) => {
+      console.log("Message recieved from server:", data);
+      if (ack) console.log("Server acknowledged message:", ack);
+      setMessages([...messages, data])
+    })
+    return () => {
+      socket.off()
+    }
+  }, [messages])
 
   // For when the user sends a message (fired by the send button)
   const onHandleSubmit = () => {
@@ -67,6 +72,7 @@ const ChatScreen = () => {
       setMessageContent("");
     }
   };
+
 
   return (
     <View

--- a/client/src/components/Chat/ChatScreen.tsx
+++ b/client/src/components/Chat/ChatScreen.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import {
   Keyboard,
   KeyboardAvoidingView,
@@ -38,6 +38,13 @@ const ChatScreen = () => {
   const [messages, setMessages] = React.useState<MessageType[]>([]);
   const [messageContent, setMessageContent] = React.useState<string>("");
 
+  if (socket === null) return // Might need to be changed.
+  socket.on("message", (data: MessageType, ack) => {
+    console.log("Message recieved from server:", data);
+    if (ack) console.log("Server acknowledged message:", ack);
+    setMessages([...messages, data])
+  })
+
   // For when the user sends a message (fired by the send button)
   const onHandleSubmit = () => {
     if (messageContent.trim() !== "") {
@@ -60,6 +67,18 @@ const ChatScreen = () => {
       setMessageContent("");
     }
   };
+
+  // useEffect(() => {
+  //   if (socket === null) {
+  //     return
+  //   }
+  //   console.log("flag")
+  //   socket.on("message", (data: MessageType, ack) => {
+  //     console.log("Message recieved from server:", data);
+  //     if (ack) console.log("Server acknowledged message:", ack);
+  //     setMessages([...messages, data])
+  //   })
+  // }, [])
 
   return (
     <View

--- a/client/src/components/Chat/ChatScreen.tsx
+++ b/client/src/components/Chat/ChatScreen.tsx
@@ -22,6 +22,8 @@ import { SignOutButton } from "../Common/AuthButtons"
 import { MessageType } from "../../types/Message";
 import { LocationProvider } from "../../contexts/LocationContext";
 import { useSocket } from "../../contexts/SocketContext";
+import { useLocation } from "../../contexts/LocationContext";
+import { AuthStore } from "../../services/store";
 
 const ChatScreen = () => {
   const settings = useSettings();
@@ -29,6 +31,8 @@ const ChatScreen = () => {
   const screenHeight = Dimensions.get("window").height;
   const keyboardBehavior = Platform.OS === "ios" ? "padding" : undefined;
   const socket = useSocket();
+  const location = useLocation();
+  const { user } = AuthStore.useState();
 
   // Message loading and sending logic
   const [messages, setMessages] = React.useState<MessageType[]>([]);
@@ -38,13 +42,13 @@ const ChatScreen = () => {
   const onHandleSubmit = () => {
     if (messageContent.trim() !== "") {
       const newMessage: MessageType = {
-        uid: "111", // TODO: get uid from firebase auth.
-        msgId: "111", // TODO: find a way to create a unique message id.
+        uid: String(user?.uid), 
+        msgId: Crypto.randomUUID(), 
         msgContent: messageContent.trim(),
         timeSent: Date.now(),
         location: {
-          lat: 10,
-          lon: 10
+          lat: Number(location?.latitude),
+          lon: Number(location?.longitude)
         }
       }
 

--- a/client/src/components/Chat/ChatScreen.tsx
+++ b/client/src/components/Chat/ChatScreen.tsx
@@ -15,30 +15,31 @@ import { ChatInput } from "../Common/CustomInputs";
 import { ChatSendButton } from "../Common/CustomButtons";
 import MessageChannel from "../Common/MessageChannel";
 import { LinearGradient } from "expo-linear-gradient";
-import { MessageType } from "../../utils/types";
 import * as Crypto from "expo-crypto";
 import { generateName } from "../../utils/scripts";
 import { useSettings } from "../../contexts/SettingsContext";
 import { SignOutButton } from "../Common/AuthButtons"
-import { Message } from "../../types/Message";
+import { MessageType } from "../../types/Message";
 import { LocationProvider } from "../../contexts/LocationContext";
+import { useSocket } from "../../contexts/SocketContext";
 
 const ChatScreen = () => {
   const settings = useSettings();
   const screenWidth = Dimensions.get("window").width;
   const screenHeight = Dimensions.get("window").height;
   const keyboardBehavior = Platform.OS === "ios" ? "padding" : undefined;
+  const socket = useSocket();
 
   // Message loading and sending logic
-  const [messages, setMessages] = React.useState<Message[]>([]);
+  const [messages, setMessages] = React.useState<MessageType[]>([]);
   const [messageContent, setMessageContent] = React.useState<string>("");
 
   // For when the user sends a message (fired by the send button)
   const onHandleSubmit = () => {
     if (messageContent.trim() !== "") {
-      const newMessage: Message = {
-        uid: "111",
-        msgId: "111",
+      const newMessage: MessageType = {
+        uid: "111", // TODO: get uid from firebase auth.
+        msgId: "111", // TODO: find a way to create a unique message id.
         msgContent: messageContent.trim(),
         timeSent: Date.now(),
         location: {
@@ -47,6 +48,10 @@ const ChatScreen = () => {
         }
       }
 
+      if (socket !== null) {
+        socket.emit("message", newMessage)
+      }
+      
       setMessages([...messages, newMessage]);
       setMessageContent("");
     }
@@ -83,9 +88,9 @@ const ChatScreen = () => {
           </View>
           <View style={styles.footerContainer}>
             <ChatInput
-              value={message}
+              value={messageContent}
               onChangeText={(text: string) => {
-                setMessage(text);
+                setMessageContent(text);
               }}
             />
             <ChatSendButton onPress={onHandleSubmit} />

--- a/client/src/components/Chat/ChatScreen.tsx
+++ b/client/src/components/Chat/ChatScreen.tsx
@@ -38,7 +38,7 @@ const ChatScreen = () => {
   const [messages, setMessages] = React.useState<MessageType[]>([]);
   const [messageContent, setMessageContent] = React.useState<string>("");
 
-  if (socket === null) return // Might need to be changed.
+  if (socket === null) return // This line might need to be changed.
   socket.on("message", (data: MessageType, ack) => {
     console.log("Message recieved from server:", data);
     if (ack) console.log("Server acknowledged message:", ack);
@@ -67,18 +67,6 @@ const ChatScreen = () => {
       setMessageContent("");
     }
   };
-
-  // useEffect(() => {
-  //   if (socket === null) {
-  //     return
-  //   }
-  //   console.log("flag")
-  //   socket.on("message", (data: MessageType, ack) => {
-  //     console.log("Message recieved from server:", data);
-  //     if (ack) console.log("Server acknowledged message:", ack);
-  //     setMessages([...messages, data])
-  //   })
-  // }, [])
 
   return (
     <View

--- a/client/src/components/Chat/ChatScreen.tsx
+++ b/client/src/components/Chat/ChatScreen.tsx
@@ -20,6 +20,8 @@ import * as Crypto from "expo-crypto";
 import { generateName } from "../../utils/scripts";
 import { useSettings } from "../../contexts/SettingsContext";
 import { SignOutButton } from "../Common/AuthButtons"
+import { Message } from "../../types/Message";
+import { LocationProvider } from "../../contexts/LocationContext";
 
 const ChatScreen = () => {
   const settings = useSettings();
@@ -28,21 +30,25 @@ const ChatScreen = () => {
   const keyboardBehavior = Platform.OS === "ios" ? "padding" : undefined;
 
   // Message loading and sending logic
-  const [messages, setMessages] = React.useState<MessageType[]>([]);
-  const [message, setMessage] = React.useState<string>("");
+  const [messages, setMessages] = React.useState<Message[]>([]);
+  const [messageContent, setMessageContent] = React.useState<string>("");
 
   // For when the user sends a message (fired by the send button)
   const onHandleSubmit = () => {
-    if (message.trim() !== "") {
-      const newMessage: MessageType = {
-        msgID: Crypto.randomUUID(),
-        messageContent: message.trim(),
-        author: generateName(),
-      };
+    if (messageContent.trim() !== "") {
+      const newMessage: Message = {
+        uid: "111",
+        msgId: "111",
+        msgContent: messageContent.trim(),
+        timeSent: Date.now(),
+        location: {
+          lat: 10,
+          lon: 10
+        }
+      }
 
       setMessages([...messages, newMessage]);
-
-      setMessage("");
+      setMessageContent("");
     }
   };
 

--- a/client/src/components/Common/ChatMessage.tsx
+++ b/client/src/components/Common/ChatMessage.tsx
@@ -4,9 +4,8 @@ import { useSettings } from "../../contexts/SettingsContext";
 
 interface MessageProps {
   messageContent: string;
-  // timestamp: Date, (This will be added later inside the message object passed in)
   author: string,
-  time: Date
+  time: number // Unix timestamp; Date.now() returns a Number.
 };
 
 const Message: React.FC<MessageProps> = ({ messageContent, author }) => {

--- a/client/src/components/Common/ChatMessage.tsx
+++ b/client/src/components/Common/ChatMessage.tsx
@@ -8,9 +8,9 @@ interface MessageProps {
   time: number // Unix timestamp; Date.now() returns a Number.
 };
 
-const Message: React.FC<MessageProps> = ({ messageContent, author }) => {
+const Message: React.FC<MessageProps> = ({ messageContent, time, author }) => {
   const settings = useSettings();
-  const timestamp = new Date().toLocaleTimeString([], {
+  const timestamp = new Date(time).toLocaleTimeString([], {
     hour: "2-digit",
     minute: "2-digit",
   });

--- a/client/src/components/Common/MessageChannel.tsx
+++ b/client/src/components/Common/MessageChannel.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import Message from './ChatMessage'
 import { FlatList, StyleSheet, View } from 'react-native'
-import { MessageType } from '../../utils/types';
+import { MessageType } from '../../types/Message'
 
 interface MessageChannelProps {
   messages: MessageType[],
@@ -16,11 +16,12 @@ const MessageChannel: React.FC<MessageChannelProps> = ({ messages }) => {
           width: '100%',
         }}
         data={reverseMessages}
-        keyExtractor={(item) => item.msgID.toString()}
+        keyExtractor={(item) => item.msgId.toString()}
         renderItem={({ item }) => (
           <Message
-            messageContent={item.messageContent}
-            author={item.author}
+            messageContent={item.msgContent}
+            author={item.uid} // TODO: call server to get author name from UID. Or should this stored with MessageType?
+            time={item.timeSent}
           />
         )}
         inverted={true} // This will render items from the bottom

--- a/client/src/contexts/LocationContext.tsx
+++ b/client/src/contexts/LocationContext.tsx
@@ -44,7 +44,7 @@ export const LocationProvider = ({
       const interval = setInterval(async () => {
         try {
           let locationData = await Location.getCurrentPositionAsync({
-            accuracy: Location.Accuracy.Highest,
+            accuracy: Location.Accuracy.High
           }); // High accuracy for now for testing!
           if (
             locationData.coords.latitude !== location.latitude ||

--- a/client/src/contexts/LocationContext.tsx
+++ b/client/src/contexts/LocationContext.tsx
@@ -60,7 +60,7 @@ export const LocationProvider = ({
         } catch (error) {
           console.error("Error fetching location:", error);
         }
-      }, LOCATION_REFRESH_RATE); // Fetch location every 3 seconds
+      }, Number(LOCATION_REFRESH_RATE)); // Send location every few seconds
 
       // Cleanup function to clear interval when component unmounts
       return () => clearInterval(interval);

--- a/client/src/contexts/LocationContext.tsx
+++ b/client/src/contexts/LocationContext.tsx
@@ -15,6 +15,12 @@ interface LocationType {
 
 const LocationContext = createContext<LocationContextProps | null>(null);
 
+const getLocation = async () => {
+  return await Location.getCurrentPositionAsync({
+    accuracy: Location.Accuracy.Balanced
+  }); // Change accuracy while testing. Could become .env variable.
+}
+
 export const useLocation = () => {
   return useContext(LocationContext);
 };
@@ -31,6 +37,7 @@ export const LocationProvider = ({
   const [isLocationEnabled, setIsLocationEnabled] = useState(false);
 
   useEffect(() => {
+    // TODO: Refactor this useEffect into a different file (service?) outside of the context, as it is not part of the purpose of a context.
     (async () => {
       // Request location permissions, if not granted, return
       let { status } = await Location.requestForegroundPermissionsAsync();
@@ -42,10 +49,9 @@ export const LocationProvider = ({
       setIsLocationEnabled(true);
 
       const interval = setInterval(async () => {
+        // FIXME: This loop does not stop after refreshing app. Must completely close out and restart app when LOCATION_REFRESH_RATE is changed.
         try {
-          let locationData = await Location.getCurrentPositionAsync({
-            accuracy: Location.Accuracy.High
-          }); // High accuracy for now for testing!
+          const locationData = await getLocation();
           if (
             locationData.coords.latitude !== location.latitude ||
             locationData.coords.longitude !== location.longitude

--- a/client/src/contexts/SettingsContext.tsx
+++ b/client/src/contexts/SettingsContext.tsx
@@ -36,6 +36,9 @@ export const SettingsProvider = ({
   children: React.ReactNode;
 }) => {
   const [theme, setTheme] = useState("light");
+  const [displayName, setDisplayName] = useState("");
+  const [foregroundPfpImage, setForegroundPfpImage] = useState("");
+  const [backgroundPfpImage, setBackgroundPfpImage] = useState("");
 
   // Initial settings load
   useEffect(() => {

--- a/client/src/contexts/SocketContext.tsx
+++ b/client/src/contexts/SocketContext.tsx
@@ -3,7 +3,7 @@ import { io, Socket } from "socket.io-client";
 import * as Network from "expo-network";
 import { useLocation } from "./LocationContext";
 import { EXPO_IP } from "@env";
-import { Message } from "../types/Message";
+import { MessageType } from "../types/Message";
 
 const SocketContext = createContext<Socket | null>(null);
 
@@ -28,7 +28,7 @@ export const SocketProvider = ({ children }: { children: React.ReactNode }) => {
       }
     });
 
-    socketIo.on("message", (data: Message, ack) => {
+    socketIo.on("message", (data: MessageType, ack) => {
       console.log("Sending message to server:", data);
       if (ack) console.log("Server acknowledged message:", ack);
     });

--- a/client/src/contexts/SocketContext.tsx
+++ b/client/src/contexts/SocketContext.tsx
@@ -3,7 +3,6 @@ import { io, Socket } from "socket.io-client";
 import * as Network from "expo-network";
 import { useLocation } from "./LocationContext";
 import { EXPO_IP } from "@env";
-import { MessageType } from "../types/Message";
 
 const SocketContext = createContext<Socket | null>(null);
 
@@ -28,10 +27,10 @@ export const SocketProvider = ({ children }: { children: React.ReactNode }) => {
       }
     });
 
-    socketIo.on("message", (data: MessageType, ack) => {
-      console.log("Sending message to server:", data);
-      if (ack) console.log("Server acknowledged message:", ack);
-    });
+    // socketIo.on("message", (data: MessageType, ack) => {
+    //   console.log("Sending message to server:", data);
+    //   if (ack) console.log("Server acknowledged message:", ack);
+    // });
 
     return () => {
       isMounted = false;
@@ -40,6 +39,7 @@ export const SocketProvider = ({ children }: { children: React.ReactNode }) => {
   }, []);
 
   useEffect(() => {
+    // TODO: Refactor this useEffect into a different file (service?) outside of the context, as it is not part of the purpose of a context.
     if (
       socket &&
       locationContext?.latitude != 9999 &&

--- a/client/src/contexts/SocketContext.tsx
+++ b/client/src/contexts/SocketContext.tsx
@@ -3,6 +3,7 @@ import { io, Socket } from "socket.io-client";
 import * as Network from "expo-network";
 import { useLocation } from "./LocationContext";
 import { EXPO_IP } from "@env";
+import { Message } from "../types/Message";
 
 const SocketContext = createContext<Socket | null>(null);
 
@@ -27,8 +28,9 @@ export const SocketProvider = ({ children }: { children: React.ReactNode }) => {
       }
     });
 
-    socketIo.on("message", (data: any) => {
-      console.log("message", data);
+    socketIo.on("message", (data: Message, ack) => {
+      console.log("Sending message to server:", data);
+      if (ack) console.log("Server acknowledged message:", ack);
     });
 
     return () => {

--- a/client/src/types/Message.ts
+++ b/client/src/types/Message.ts
@@ -1,0 +1,11 @@
+export interface Message {
+    uid: string
+    msgId: string
+    msgContent: string
+    timeSent: number
+    location: {
+        lat: number
+        lon: number
+        geohash?: string
+    }
+}

--- a/client/src/types/Message.ts
+++ b/client/src/types/Message.ts
@@ -1,8 +1,9 @@
-export interface Message {
+export interface MessageType {
     uid: string
+    authorName?: string // To be only used for display purposes (i.e. do not send to server)
     msgId: string
     msgContent: string
-    timeSent: number
+    timeSent: number // Unix timestamp; Date.now() returns a Number.
     location: {
         lat: number
         lon: number

--- a/client/src/utils/types.ts
+++ b/client/src/utils/types.ts
@@ -1,6 +1,0 @@
-export type MessageType = {
-  messageContent: string;
-  author: string;
-  msgID: string;
-  timestamp: Date;
-};

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -88,7 +88,7 @@ io.on('connection', (socket: any) => {
           continue
         } else {
           console.log(`Sending new message to socket ${recievingSocket}`)
-          socket.broadcast.to(recievingSocket).emit("message", message.msgContent)
+          socket.broadcast.to(recievingSocket).emit("message", message)
         }
       }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -88,7 +88,6 @@ io.on('connection', (socket: any) => {
         } else {
           console.log(`Sending new message to socket ${recievingSocket}`)
           socket.broadcast.to(recievingSocket).emit("message", message.msgContent)
-          // socket.broadcast.to(recievingSocket).emit("message", message)
         }
       }
 

--- a/server/src/tests/socketio.test.ts
+++ b/server/src/tests/socketio.test.ts
@@ -1,147 +1,146 @@
-// // Testing for socket.io endpoints
+// Testing for socket.io endpoints
 
-// import { io as io } from 'socket.io-client'
-// import { v4 as uuidv4 } from 'uuid';
-// import { Message } from '../types/Message';
+import { io as io } from 'socket.io-client'
+import { v4 as uuidv4 } from 'uuid';
+import { Message } from '../types/Message';
 
-// const socket_test_client_port = process.env.socket_test_client_port;
-// console.log("Socket clients are listening on port", socket_test_client_port)
+const socket_test_client_port = process.env.socket_test_client_port;
+console.log("Socket clients are listening on port", socket_test_client_port)
 
-// const SECONDS_TIMEOUT = 10;
-// const SECONDS_MULTIPLIER = 1000;
-// const NUM_CLIENTS = 10; // Adjust the number of clients as needed. Do not go over 300 to prevent being blocked by Firebase.
-// const exampleMsg: Message = {
-//     uid: "USER ID",
-//     msgId: "MESSAGE ID",
-//     msgContent: "MESSAGE CONTENT",
-//     timeSent: 9999,
-//     location: {
-//         lat: 10,
-//         lon: 10
-//         // Geohash will be calculated by the server since it is not included with the message.
-//     }
-// }
+const SECONDS_TIMEOUT = 10;
+const SECONDS_MULTIPLIER = 1000;
+const NUM_CLIENTS = 3; // Adjust the number of clients as needed. Do not go over 300 to prevent being blocked by Firebase.
+const exampleMsg: Message = {
+    uid: uuidv4(), // random Ids; not a real UID
+    msgId: uuidv4(),
+    msgContent: "MESSAGE CONTENT",
+    timeSent: 9999,
+    location: {
+        lat: 10,
+        lon: 10
+        // Geohash will be calculated by the server since it is not included with the message.
+    }
+}
 
-// jest.setTimeout(SECONDS_TIMEOUT * SECONDS_MULTIPLIER);
+jest.setTimeout(SECONDS_TIMEOUT * SECONDS_MULTIPLIER);
 
-// const sleep = (ms) => {
-//   return new Promise(resolve => setTimeout(resolve, ms));
-// };
+const sleep = (ms) => {
+  return new Promise(resolve => setTimeout(resolve, ms));
+};
 
-// const connectClients = async () => {
-//   const clients = [];
+const connectClients = async () => {
+  const clients = [];
 
-//   for (let i = 0; i < NUM_CLIENTS; i++) {
-//     const client = io(`http://localhost:${socket_test_client_port}`);
-//     await new Promise(resolve => client.on('connect', resolve)); // Why is this an error? IDK
-//     clients.push(client);
-//   }
+  for (let i = 0; i < NUM_CLIENTS; i++) {
+    const client = io(`http://localhost:${socket_test_client_port}`);
+    await new Promise(resolve => client.on('connect', resolve)); // Why is this an error? IDK
+    clients.push(client);
+  }
 
-//   return clients;
-// };
+  return clients;
+};
 
-// const disconnectClients = (clients) => {
-//   clients.forEach(client => client.disconnect());
-// };
+const disconnectClients = (clients) => {
+  clients.forEach(client => client.disconnect());
+};
 
-// describe('socket-load-tests', () => {
-//   let clients;
+describe('socket-load-tests', () => {
+  let clients;
 
-//   beforeAll(async () => {
-//     clients = await connectClients();
-//   });
+  beforeAll(async () => {
+    clients = await connectClients();
+  });
 
-//   afterAll(() => {
-//     disconnectClients(clients);
-//   });
+  afterAll(() => {
+    disconnectClients(clients);
+  });
 
-//   test('Simultaneous Ping', async () => {
-//     const pingPromises = clients.map(client => new Promise(resolve => client.emit('ping', resolve)));
-//     const responses = await Promise.all(pingPromises);
+  test('Simultaneous Ping', async () => {
+    const pingPromises = clients.map(client => new Promise(resolve => client.emit('ping', resolve)));
+    const responses = await Promise.all(pingPromises);
 
-//     responses.forEach(response => {
-//       expect(response).toBe('pong');
-//     });
-//   });
+    responses.forEach(response => {
+      expect(response).toBe('pong');
+    });
+  });
 
-//   test('Simultaneous Message', async () => {
-//     let count = 0;
-//     const messagePromises = clients.map(client => {
-//       return new Promise(async resolve => {
-//         client.emit('message', exampleMsg, resolve);
-//         count++;
-//         await sleep(200)
-//       });
-//     });
+  test('Simultaneous Message', async () => {
+    let count = 0;
+    const messagePromises = clients.map(client => {
+      return new Promise(async resolve => {
+        client.emit('message', exampleMsg, resolve);
+        count++;
+        await sleep(200)
+      });
+    });
 
-//     const responses = await Promise.all(messagePromises);
-//     responses.forEach(response => {
-//       expect(response).toBe('message recieved');
-//     });
-//   })
-// });
+    const responses = await Promise.all(messagePromises);
+    responses.forEach(response => {
+      expect(response).toBe('message recieved');
+    });
+  })
+});
 
-// describe("socket-tests", () => {
-//     let user1, user2, user3, user4, user5
-//     let userList = [user1, user2, user3, user4, user5]
-//     let user2Id
+describe("socket-tests", () => {
+    let user1, user2
 
-//     beforeAll((done) => {
-//         user1 = io(`http://localhost:${socket_test_client_port}`)
-//         user1.on('connect', done)
-//         user2 = io(`http://localhost:${socket_test_client_port}`)
-//         user2.on('connect', done)
-//     })
+    beforeAll((done) => {
+        user1 = io(`http://localhost:${socket_test_client_port}`)
+        user1.on('connect', done)
+        user2 = io(`http://localhost:${socket_test_client_port}`)
+        user2.on('connect', done)
+    })
 
-//     afterAll(() => {
-//         user1.disconnect()
-//         user2.disconnect()
-//     })
+    afterAll(() => {
+        user1.disconnect()
+        user2.disconnect()
+    })
 
-//     test('Ping', (done) => {
-//         user1.emit('ping', (response) => {
-//             expect(response).toBe('pong')
-//             done()
-//         })
-//     })
-//     test('Send message', (done) => {
-//         user1.emit('message', exampleMsg, (response) => {
-//             expect(response).toBe('message recieved')
-//             done()
-//         })
-//     })
-//     test('Update locations', (done) => {
-//         const user1Coords = { lat: 29.64888, lon: -82.34420 } // Turlington Hall pin on Google Maps
-//         const user2Coords = { lat: 29.64881, lon: -82.34429 } // 8.65 meters SW of user 1
-//         user1.emit('updateLocation', user1Coords, (response) => {
-//             expect(response).toBe("location updated")
-//         }) 
-//         user2.emit('updateLocation', user2Coords, (response) => {
-//             expect(response).toBe("location updated")
-//         })
-//         sleep(5000)
-//         done()
-//     })
-//     test('Send message to user', async (done) => {
-//         const user2Coords = { lat: 29.64881, lon: -82.34429 } // 8.65 meters SW of user 1
-//         const user2Message: Message = {
-//             uid: user2.id, // a socket id
-//             msgId: "MESSAGE ID",
-//             msgContent: "omggg hi!!!! :3",
-//             timeSent: 9999,
-//             location: {
-//                 lat: user2Coords.lat,
-//                 lon: user2Coords.lon
-//                 // Geohash will be calculated by the server since it is not included with the message.
-//             }
-//         }
-//         user1.on('message', (message) => {
-//             console.log(`User 2 recieved message: ${message}`)
-//             expect(message).toBe("omggg hi!!!! :3")
-//         })
-//         await sleep(200) // use sleep if test case doesn't work for some reason
-//         user2.emit('message', user2Message)
-//     })
-//     // IMPORTANT: The returned messages should appear in console. The correct way to use expect() has not been figured out yet for this test.
-//     // TODO: Find a way for expect() to be verified after messages return. 
-// })
+    test('Ping', (done) => {
+        user1.emit('ping', (response) => {
+            expect(response).toBe('pong')
+            done()
+        })
+    })
+    test('Send message', (done) => {
+        user1.emit('message', exampleMsg, (response) => {
+            expect(response).toBe('message recieved')
+            done()
+        })
+    })
+    test('Update locations', (done) => {
+        const user1Coords = { lat: 29.64888, lon: -82.34420 } // Turlington Hall pin on Google Maps
+        const user2Coords = { lat: 29.64881, lon: -82.34429 } // 8.65 meters SW of user 1
+        user1.emit('updateLocation', user1Coords, (response) => {
+            expect(response).toBe("location updated")
+        }) 
+        user2.emit('updateLocation', user2Coords, (response) => {
+            expect(response).toBe("location updated")
+        })
+        sleep(5000)
+        done()
+    })
+    test('Send message to user', async (done) => {
+        // const user2Coords = { lat: 29.64881, lon: -82.34429 } // 8.65 meters SW of user 1
+        const user2Coords = { lat: 29.6489940, lon: -82.344096 } // 8.65 meters SW of user 1
+        const user2Message: Message = {
+            uid: user2.id, // a socket id
+            msgId: uuidv4(),
+            msgContent: "omggg hi!!!! :3",
+            timeSent: 9999,
+            location: {
+                lat: user2Coords.lat,
+                lon: user2Coords.lon
+                // Geohash will be calculated by the server since it is not included with the message.
+            }
+        }
+        user1.on('message', (message: Message) => {
+            console.log(`User 2 recieved message: ${message}`)
+            expect(message.msgContent).toBe("omggg hi!!!! :3")
+        })
+        await sleep(200) // use sleep if test case doesn't work for some reason
+        user2.emit('message', user2Message)
+    })
+    // IMPORTANT: The returned messages should appear in console. The correct way to use expect() has not been figured out yet for this test.
+    // TODO: Find a way for expect() to be verified after messages return. 
+})


### PR DESCRIPTION
This PR re-adds echologation while utilizing websockets and our new database schemas.

The location and socket contexts are used within ChatScreen.tsx, as well as the AuthStore to retrieve the UID of the logged in user.
Some issues I found while working on this include some poor functionality segmentation within these contexts (ie. some things within the context useEffects should be moved to functions in seperate files), a problem with the location refreshing (entire app needs to be closed out since the loop never stops). Appropriate FIXMEs and READMEs have been put within these files, and future issues will be made shortly.

A bug was also fixed to display time correctly on each message (the current time used to be displayed on all of them), and testing has been updated to be consistent with the server now emitting entire messages (not `message.msgContent`s back to clients).

Additionally, a couple of new parameters was added to the settingsContext for storing the users current displayName and profile picture data. We're going to need to either write a service or use a different message type specific to the frontend to retrieve and display this information easily on every message, though.

Please discuss if you have any questions, this is a large PR. Also feel free to commit to my branch if you need to make changes.