### PR TITLE
Added settings pullstate and settings store

### DIFF
--- a/client/src/services/SettingsStore.ts
+++ b/client/src/services/SettingsStore.ts
@@ -1,15 +1,15 @@
 import { Store } from "pullstate";
 
-interface SettingsInterface  {
+interface SettingsInterface {
   isDarkMode: boolean;
-};
+}
 
 export const SettingStore = new Store<SettingsInterface>({
-    isDarkMode: false,
+  isDarkMode: false,
 });
 
-export const toggleTheme = async() => {
-    SettingStore.update((store) => {
-        store.isDarkMode = !store.isDarkMode; 
-    });
+export const toggleTheme = async () => {
+  SettingStore.update((store) => {
+    store.isDarkMode = !store.isDarkMode;
+  });
 };

--- a/client/src/services/SettingsStore.ts
+++ b/client/src/services/SettingsStore.ts
@@ -1,0 +1,15 @@
+import { Store } from "pullstate";
+
+interface SettingsInterface  {
+  isDarkMode: boolean;
+};
+
+export const SettingStore = new Store<SettingsInterface>({
+    isDarkMode: false,
+});
+
+export const toggleTheme = async() => {
+    SettingStore.update((store) => {
+        store.isDarkMode = !store.isDarkMode; 
+    });
+};


### PR DESCRIPTION
Closes #213 
Replaces SettingsContext with SettingsStore within the services folder which can be used to retrieve dark mode or light mode and toggle between them within the settings screen. Uses pullstate.