### PR TITLE
typo in path

### DIFF
--- a/server/src/utilities/firebaseInit.ts
+++ b/server/src/utilities/firebaseInit.ts
@@ -1,5 +1,5 @@
 const admin = require('firebase-admin');
-const serviceAccount = require("../../firebase-secrets.json");
+const serviceAccount = require("../../.firebase-secrets.json");
 
 export const adminApp = admin.initializeApp({
   credential: admin.credential.cert(serviceAccount),


### PR DESCRIPTION
Tried setting up the project again and I found a typo in this path when comparing against the documentation in server/config_example.md.