### PR TITLE
Create UserConfig Collection after User Signup

### DIFF
--- a/client/app/configs/firebaseConfig.ts
+++ b/client/app/configs/firebaseConfig.ts
@@ -1,4 +1,4 @@
-import { API_KEY, AUTH_DOMAIN } from "@env"; // Don't worry about this env error!
+import { API_KEY, AUTH_DOMAIN, PROJECT_ID } from "@env"; // Don't worry about this env error!
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { initializeApp, getApp, getApps } from "@firebase/app";
 import {
@@ -12,6 +12,7 @@ import { getFirestore } from "@firebase/firestore";
 const firebaseConfig = {
   apiKey: API_KEY || "Mock-Key",
   authDomain: AUTH_DOMAIN,
+  projectId: PROJECT_ID,
 };
 
 let app;

--- a/client/app/configs/firebaseConfig.ts
+++ b/client/app/configs/firebaseConfig.ts
@@ -7,6 +7,7 @@ import {
   getAuth,
   Auth,
 } from "@firebase/auth";
+import { getFirestore } from "@firebase/firestore";
 
 const firebaseConfig = {
   apiKey: API_KEY || "Mock-Key",
@@ -31,4 +32,5 @@ if (!getApps().length) {
   auth = getAuth();
 }
 
+export const db = getFirestore(); //Export Const DB for UserConfig
 export { app, auth };

--- a/client/app/services/AuthStore.ts
+++ b/client/app/services/AuthStore.ts
@@ -24,12 +24,22 @@ export const AuthStore = new Store<AuthStoreInterface>({
 
 const createUserConfig = async (userId: string) => {
   try {
-    const docRef = doc(db, "UserConfig", userId);
+    const docRef = doc(db, "UserConfigs", userId);
 
     await setDoc(docRef, {
+      // TODO: create a matching UserConfig type in the app/types folder.
+      // In documentation: make explicit that the key for UserConfig documents is the same as a uid from the user auth collection.
+      isConnected: false,
+      lastConnectionTime: "",
+      displayName: "",
+      userIcon: {
+        imageType: 0,
+        color: "#02efdb"
+      },
       darkMode: false,
       notificationsEnabled: false,
       language: "English",
+      
     });
   } catch (e){
     console.error("Error creating UserConfig: ", e);

--- a/client/config_example.md
+++ b/client/config_example.md
@@ -14,3 +14,4 @@ LOCATION_REFRESH_RATE=3000
 
 API_KEY = place_your_apiKey_here
 AUTH_DOMAIN = place_your_authDomain_here
+PROJECT_ID = place_your_projectId_here


### PR DESCRIPTION
**Description**

This PR adds the functionality to automatically create a UserConfig document in Firebase Firestore after a user signs up in the app.

**Key Changes:**
- A new method createUserConfig has been added to the AuthStore.ts class.
- After user signup, createUserConfig is called, which creates a UserConfig document in Firestore for the newly registered user.
- The UserConfig collection is initialized with the following default fields:
  - darkMode: false (indicating that dark mode is disabled by default)
  - notificationsEnabled: false (indicating that notifications are disabled by default)
  - language: 'English' (default language setting)

This ensures that each new user has a personalized configuration stored, which can be updated later according to user preferences.